### PR TITLE
fix: set exit code based on executed command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ node_modules
 oclif.manifest.json
 oclif.lock
 npm-shrinkwrap.json
+.idea/

--- a/src/commands/force/lightning/lwc/test/run.ts
+++ b/src/commands/force/lightning/lwc/test/run.ts
@@ -55,6 +55,7 @@ export default class Run extends SfdxCommand {
     const scriptRet = this.runJest(args);
 
     this.ux.log(messages.getMessage('logSuccess', [scriptRet.status.toString()]));
+    process.exitCode=scriptRet.status;
     return {
       message: messages.getMessage('logSuccess', [scriptRet.status.toString()]),
       jestExitCode: scriptRet.status,

--- a/test/commands/lwc/test/run.nut.ts
+++ b/test/commands/lwc/test/run.nut.ts
@@ -81,7 +81,7 @@ describe('lightning:lwc:test:run', () => {
     await fs.promises.writeFile(testPath, content);
 
     const output = execCmd<RunResult>('force:lightning:lwc:test:run', {
-      ensureExitCode: 0,
+      ensureExitCode: 1,
     }).shellOutput.stderr;
     expect(output).to.include('Test Suites: 1 failed');
     expect(output).to.include('Tests:       1 failed');

--- a/test/commands/lwc/test/setup.nut.ts
+++ b/test/commands/lwc/test/setup.nut.ts
@@ -55,9 +55,9 @@ describe('lightning:lwc:test:setup', () => {
     content = await fs.promises.readFile(pjsonPath, 'utf-8');
     const forceignoreContent = fs.readFileSync(forceignorePath, 'utf-8');
     expect(forceignoreContent).to.include('**/__tests__/**');
-    expect(content).to.include('"test:unit": "sfdx-lwc-jest --skipApiVersionCheck"');
-    expect(content).to.include('"test:unit:coverage": "sfdx-lwc-jest --coverage --skipApiVersionCheck"');
-    expect(content).to.include('"test:unit:debug": "sfdx-lwc-jest --debug --skipApiVersionCheck"');
+    expect(content).to.include('"test:unit": "sfdx-lwc-jest"');
+    expect(content).to.include('"test:unit:coverage": "sfdx-lwc-jest --coverage "');
+    expect(content).to.include('"test:unit:debug": "sfdx-lwc-jest --debug "');
     expect(content).to.include('"@salesforce/sfdx-lwc-jest": "^');
   });
 });


### PR DESCRIPTION
### What does this PR do?

sets command's exit code based on jest's exit code

### What issues does this PR fix or reference?
@W-16884223@
https://github.com/forcedotcom/cli/issues/2991